### PR TITLE
add checkstyle asserting license headers on all source files, resolve…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ subprojects {
     version = rootProject.version
 
     apply plugin: "java"
+    apply plugin: "checkstyle"
 
     ext {
         versions = [
@@ -22,6 +23,13 @@ subprojects {
             url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local")
         }
         mavenCentral()
+    }
+
+    checkstyle {
+        configFile = rootProject.file('checkstyle.xml') as File
+        configProperties = [
+            'licenseHeader': rootProject.file('license_header.txt')
+        ]
     }
 
     dependencies {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="warning"/>
+    <!-- Verify that each source file starts with the correct license header. See build.gradle for location of ${licenseHeader}. -->
+    <module name="Header">
+        <property name="severity" value="error"/>
+        <property name="headerFile" value="${licenseHeader}" />
+    </module>
+</module>

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,4 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/newrelic-opentelemetry-javaagent/src/main/java/com/newrelic/telemetry/NewRelicAgent.java
+++ b/newrelic-opentelemetry-javaagent/src/main/java/com/newrelic/telemetry/NewRelicAgent.java
@@ -1,7 +1,10 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.newrelic.telemetry;
 
 import io.opentelemetry.javaagent.OpenTelemetryAgent;
-
 import java.lang.instrument.Instrumentation;
 
 public class NewRelicAgent {

--- a/smoke-tests/src/test/java/com/newrelic/telemetry/OkHttpUtils.java
+++ b/smoke-tests/src/test/java/com/newrelic/telemetry/OkHttpUtils.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.newrelic.telemetry;
 
 import java.util.concurrent.TimeUnit;

--- a/smoke-tests/src/test/java/com/newrelic/telemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/newrelic/telemetry/SmokeTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.newrelic.telemetry;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/smoke-tests/src/test/java/com/newrelic/telemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/newrelic/telemetry/SpringBootSmokeTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.newrelic.telemetry;
 
 import io.opentelemetry.api.trace.TraceId;


### PR DESCRIPTION
In addition to adding the required license headers to all source files, I wanted to find a way to add a verification step to assert that the correct file headers are always present as a pre-merge check. 

I explored a couple of options. The first route I went down was the [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin), but I decided to move on because I couldn't get it to behave consistently and it seems like the project is no longer actively maintained. 

Then I realized that this type of check is very similar to the type of thing that checkstyle does. I did some searching and found that there's a checkstyle module called [Header](https://checkstyle.sourceforge.io/config_header.html) that does exactly what I was looking for. 

I know we don't use checkstyle widely in our other repos, but it seems like this is too good of a fit to overlook. In this PR, I demonstrate how we can use checkstyle in a very narrow capacity, only using it to validate the license headers. If we decide we want to expand the types of things we want to check with checkstyle (I know we use `google-java-format` with has quite a bit of overlap) we can do so as needed. 

To perform checkstyle verification, simply run `./gradlew checkstyleMain checkstyleTest`. It also is run as a part of `./gradlew build`, or `./gradlew check`. 