### PR TITLE
Add support for OTel 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Coming soon
+- tbd
+
+## [0.11.0] - 2020-12-11
+- Minor compatibility updates, adds support for OpenTelemetry `0.11.n`
+- Bundles `io.opentelemetry.javaagent:opentelemetry-javaagent:0.11.0:all` with `com.newrelic.telemetry:opentelemetry-exporters-newrelic-auto:0.11.0`.
+
+## [0.10.1] - 2020-12-07
+- Initial release, adds support for OpenTelemetry `0.10.n`
+- Bundles `io.opentelemetry.javaagent:opentelemetry-javaagent:0.10.1:all` with `com.newrelic.telemetry:opentelemetry-exporters-newrelic-auto:0.10.0`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A custom distribution of the OpenTelemetry Java agent that uses the [New Relic O
 The New Relic OpenTelemetry Integration is a standard Java agent. To use it, you just need the `-javaagent` startup flag and the following system properties. 
 
 ```
--javaagent:/path/to/newrelic-opentelemetry-javaagent-all.jar
+-javaagent:/path/to/newrelic-opentelemetry-javaagent-*-all.jar
 -Dnewrelic.api.key=<Insights Insert Key>
 -Dnewrelic.service.name=fun_service
 ```
@@ -20,7 +20,7 @@ it uses the same system properties.
 Here is an example that overrides the endpoints where metric and span data is sent (e.g. EU region instead of default US region) and increases the logging level.
 
 ```
--javaagent:/path/to/newrelic-opentelemetry-javaagent-all.jar
+-javaagent:/path/to/newrelic-opentelemetry-javaagent-*-all.jar
 -Dnewrelic.api.key=<Insights Insert Key>
 -Dnewrelic.service.name=fun_service
 -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug
@@ -59,13 +59,18 @@ For general querying information, see:
 
 ## Building
 
-**Requirements:** JDK 11+
+**Requirements:**
+* JDK 8+
 
 To build run the following command:
 
 `./gradlew assemble`
 
 ## Testing
+
+**Requirements:**
+* JDK 8+
+* Docker
 
 `smoke-tests` contains simple tests to verify that the resulting agent builds and applies correctly.
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetryExportersNewRelic : "0.10.0",
-                opentelemetryJavaagent         : "0.10.1"
+                opentelemetryExportersNewRelic : "0.11.0",
+                opentelemetryJavaagent         : "0.11.0"
         ]
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@
 # Passing in -Prelease=true will render a non-snapshot version.
 # All other values (including unset) will render a snapshot version.
 
-baseVersion = 0.10.1
+baseVersion = 0.11.0

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -8,8 +8,8 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
   testImplementation("com.google.protobuf:protobuf-java-util:3.12.4")
   testImplementation("com.squareup.okhttp3:okhttp:3.12.12")
-  testImplementation("io.opentelemetry:opentelemetry-proto:0.10.0")
-  testImplementation("io.opentelemetry:opentelemetry-api:0.10.0")
+  testImplementation("io.opentelemetry:opentelemetry-proto:0.11.0")
+  testImplementation("io.opentelemetry:opentelemetry-api:0.11.0")
 
   testImplementation("ch.qos.logback:logback-classic:1.2.3")
 }


### PR DESCRIPTION
Addresses #38 

Tested Spring pet clinic  with snapshot:

```
-javaagent:/Users/jkeller/code/newrelic-opentelemetry-integration-java/newrelic-opentelemetry-javaagent/build/libs/newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-all.jar
-Dnewrelic.api.key=KEY
-Dnewrelic.service.name=otel-distro-test
-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug
-Dnewrelic.enable.audit.logging=true
```

```
[opentelemetry.auto.trace 2020-12-11 12:32:44:857 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://trace-api.newrelic.com/trace/v1
[opentelemetry.auto.trace 2020-12-11 12:32:44:858 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-11 12:32:44:880 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed span exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter
[opentelemetry.auto.trace 2020-12-11 12:32:44:886 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://metric-api.newrelic.com/metric/v1
[opentelemetry.auto.trace 2020-12-11 12:32:44:886 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-11 12:32:44:888 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed metric exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter
[opentelemetry.auto.trace 2020-12-11 12:32:44:899 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0

...

[opentelemetry.auto.trace 2020-12-11 12:32:54:997 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.SpanBatchSender - Sending a span batch (number of spans: 4) to the New Relic span ingest endpoint)
[opentelemetry.auto.trace 2020-12-11 12:32:54:997 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.json.SpanBatchMarshaller - Generating json for span batch.
[opentelemetry.auto.trace 2020-12-11 12:32:54:997 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json: [{"common":{"attributes":{"telemetry.sdk.language":"java","service.name":"otel-distro-test","service.instance.id":"43b7d268-51f7-4951-a26d-a5273d3c8cd1","telemetry.sdk.version":"0.11.0","telemetry.auto.version":"newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0","collector.name":"newrelic-opentelemetry-exporter","instrumentation.provider":"opentelemetry","telemetry.sdk.name":"opentelemetry"}},"spans":[{"id":"c929b7909fca4f13","trace.id":"f5bbcee6c1eecb23cd2aae38e53c2890","timestamp":1607718770765,"attributes":{"duration.ms":5.262001,"db.connection_string":"h2:mem:","instrumentation.version":"newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0","db.user":"sa","db.statement":"SELECT NAME, VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME IN (?, ?, ?, ?)","span.kind":"CLIENT","db.system":"h2","name":"SELECT c36288ff-2603-45e8-a957-88cb9b1bf213.INFORMATION_SCHEMA.SETTINGS","instrumentation.name":"io.opentelemetry.javaagent.jdbc","thread.name":"task-1","thread.id":44,"db.name":"c36288ff-2603-45e8-a957-88cb9b1bf213"}},{"id":"f25c9c672e0eacd2","trace.id":"e254504e62f28701e31296c13db3fca1","timestamp":1607718770782,"attributes":{"duration.ms":1.591087,"db.connection_string":"h2:mem:","instrumentation.version":"newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0","db.user":"sa","db.statement":"SELECT TYPE_NAME, DATA_TYPE, PRECISION, PREFIX LITERAL_PREFIX, SUFFIX LITERAL_SUFFIX, PARAMS CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, FALSE UNSIGNED_ATTRIBUTE, FALSE FIXED_PREC_SCALE, AUTO_INCREMENT, TYPE_NAME LOCAL_TYPE_NAME, MINIMUM_SCALE, MAXIMUM_SCALE, DATA_TYPE SQL_DATA_TYPE, ZERO() SQL_DATETIME_SUB, RADIX NUM_PREC_RADIX FROM INFORMATION_SCHEMA.TYPE_INFO ORDER BY DATA_TYPE, POS","span.kind":"CLIENT","db.system":"h2","name":"SELECT c36288ff-2603-45e8-a957-88cb9b1bf213.INFORMATION_SCHEMA.TYPE_INFO","instrumentation.name":"io.opentelemetry.javaagent.jdbc","thread.name":"task-1","thread.id":44,"db.name":"c36288ff-2603-45e8-a957-88cb9b1bf213"}},{"id":"450e4212a414a0c4","trace.id":"d245ab856c929495eb79996bb4313296","timestamp":1607718770795,"attributes":{"duration.ms":0.475141,"db.connection_string":"h2:mem:","instrumentation.version":"newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0","db.user":"sa","db.statement":"select * from INFORMATION_SCHEMA.SEQUENCES","span.kind":"CLIENT","db.system":"h2","name":"SELECT c36288ff-2603-45e8-a957-88cb9b1bf213.INFORMATION_SCHEMA.SEQUENCES","instrumentation.name":"io.opentelemetry.javaagent.jdbc","thread.name":"task-1","thread.id":44,"db.name":"c36288ff-2603-45e8-a957-88cb9b1bf213"}},{"id":"f4b7b5dfa8afccdc","trace.id":"a72d6552d072f703eccc46c60a9dafc0","timestamp":1607718770805,"attributes":{"duration.ms":0.18454,"db.connection_string":"h2:mem:","instrumentation.version":"newrelic-opentelemetry-javaagent-0.11.0-SNAPSHOT-otel-0.11.0","db.user":"sa","db.statement":"SELECT TYPE_NAME, DATA_TYPE, PRECISION, PREFIX LITERAL_PREFIX, SUFFIX LITERAL_SUFFIX, PARAMS CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, FALSE UNSIGNED_ATTRIBUTE, FALSE FIXED_PREC_SCALE, AUTO_INCREMENT, TYPE_NAME LOCAL_TYPE_NAME, MINIMUM_SCALE, MAXIMUM_SCALE, DATA_TYPE SQL_DATA_TYPE, ZERO() SQL_DATETIME_SUB, RADIX NUM_PREC_RADIX FROM INFORMATION_SCHEMA.TYPE_INFO ORDER BY DATA_TYPE, POS","span.kind":"CLIENT","db.system":"h2","name":"SELECT c36288ff-2603-45e8-a957-88cb9b1bf213.INFORMATION_SCHEMA.TYPE_INFO","instrumentation.name":"io.opentelemetry.javaagent.jdbc","thread.name":"task-1","thread.id":44,"db.name":"c36288ff-2603-45e8-a957-88cb9b1bf213"}}]}]
[opentelemetry.auto.trace 2020-12-11 12:32:55:292 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API: code: 202, body: {"requestId":"a3318bfa-0001-b000-0000-01765381a903"}
[opentelemetry.auto.trace 2020-12-11 12:32:55:292 -0800] [Thread-6] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry batch sent
```

Trace in APM:

<img width="993" alt="dt" src="https://user-images.githubusercontent.com/3496648/101953014-777d9800-3bae-11eb-9d0a-8d1aa8f5cf1e.png">
