### PR TITLE
Update to use v0.12.0 OTel exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 - tbd
 
+## [0.12.0] - 2020-12-11
+- Minor compatibility updates, adds support for OpenTelemetry `0.12.n`
+- Bundles `io.opentelemetry.javaagent:opentelemetry-javaagent:0.12.1:all` with `com.newrelic.telemetry:opentelemetry-exporters-newrelic-auto:0.12.0`.
+
 ## [0.11.0] - 2020-12-11
 - Minor compatibility updates, adds support for OpenTelemetry `0.11.n`
 - Bundles `io.opentelemetry.javaagent:opentelemetry-javaagent:0.11.0:all` with `com.newrelic.telemetry:opentelemetry-exporters-newrelic-auto:0.11.0`.

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetryExportersNewRelic : "0.11.0",
-                opentelemetryJavaagent         : "0.11.0"
+                opentelemetryExportersNewRelic : "0.12.0",
+                opentelemetryJavaagent         : "0.12.1"
         ]
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@
 # Passing in -Prelease=true will render a non-snapshot version.
 # All other values (including unset) will render a snapshot version.
 
-baseVersion = 0.11.0
+baseVersion = 0.12.0

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -8,8 +8,8 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
   testImplementation("com.google.protobuf:protobuf-java-util:3.12.4")
   testImplementation("com.squareup.okhttp3:okhttp:3.12.12")
-  testImplementation("io.opentelemetry:opentelemetry-proto:0.11.0")
-  testImplementation("io.opentelemetry:opentelemetry-api:0.11.0")
+  testImplementation("io.opentelemetry:opentelemetry-proto:0.12.0")
+  testImplementation("io.opentelemetry:opentelemetry-api:0.12.0")
 
   testImplementation("ch.qos.logback:logback-classic:1.2.3")
 }


### PR DESCRIPTION
Resolves #39 

```
-javaagent:/Users/jkeller/code/newrelic-opentelemetry-integration-java/newrelic-opentelemetry-javaagent/build/libs/newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-all.jar
-Dnewrelic.api.key=KEY
-Dnewrelic.service.name=otel-distro-test
-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug
-Dnewrelic.enable.audit.logging=true
```

```
[opentelemetry.auto.trace 2020-12-15 15:51:30:330 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://trace-api.newrelic.com/trace/v1
[opentelemetry.auto.trace 2020-12-15 15:51:30:331 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-15 15:51:30:359 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed span exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter
[opentelemetry.auto.trace 2020-12-15 15:51:30:368 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://metric-api.newrelic.com/metric/v1
[opentelemetry.auto.trace 2020-12-15 15:51:30:368 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-15 15:51:30:371 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed metric exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter
[opentelemetry.auto.trace 2020-12-15 15:51:30:395 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-otel-0.12.1

...

[opentelemetry.auto.trace 2020-12-15 15:51:55:716 -0800] [Thread-8] DEBUG com.newrelic.telemetry.spans.SpanBatchSender - Sending a span batch (number of spans: 3) to the New Relic span ingest endpoint)
[opentelemetry.auto.trace 2020-12-15 15:51:55:716 -0800] [Thread-8] DEBUG com.newrelic.telemetry.spans.json.SpanBatchMarshaller - Generating json for span batch.
[opentelemetry.auto.trace 2020-12-15 15:51:55:716 -0800] [Thread-8] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json: [{"common":{"attributes":{"service.name":"otel-distro-test","process.runtime.version":"11.0.8+10","process.pid":53626,"telemetry.sdk.name":"opentelemetry","telemetry.sdk.language":"java","process.runtime.name":"OpenJDK Runtime Environment","service.instance.id":"eeda1f2b-26ca-4de9-aca0-a778c9403f86","os.description":"Mac OS X 10.15.7","process.executable.path":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java","process.command_line":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java -javaagent:/Users/jkeller/code/newrelic-opentelemetry-integration-java/newrelic-opentelemetry-javaagent/build/libs/newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-all.jar -Dnewrelic.api.key=NRII-Jg0aDK9COoJZM6KbJkL3gcciE8fkF5Fi -Dnewrelic.service.name=otel-distro-test -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug -Dnewrelic.enable.audit.logging=true -XX:TieredStopAtLevel=1 -Xverify:none -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=51061:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8","os.name":"DARWIN","telemetry.sdk.version":"0.12.0","process.runtime.description":"AdoptOpenJDK OpenJDK 64-Bit Server VM 11.0.8+10","telemetry.auto.version":"newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-otel-0.12.1","collector.name":"newrelic-opentelemetry-exporter","instrumentation.provider":"opentelemetry"}},"spans":[{"id":"96c0c5ae127ff367","trace.id":"fa6d11526ed1f9df15ef94a19381515d","timestamp":1608076314664,"attributes":{"duration.ms":205.078548,"instrumentation.version":"newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-otel-0.12.1","span.kind":"INTERNAL","name":"WelcomeController.welcome","parent.id":"e14f22f12bee5a7d","instrumentation.name":"io.opentelemetry.javaagent.spring-webmvc","thread.name":"http-nio-8080-exec-1","thread.id":209}},{"id":"b63a8cda0bd77239","trace.id":"fa6d11526ed1f9df15ef94a19381515d","timestamp":1608076314869,"attributes":{"duration.ms":633.716273,"instrumentation.version":"newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-otel-0.12.1","spring-webmvc.view.name":"welcome","span.kind":"INTERNAL","name":"Render welcome","parent.id":"e14f22f12bee5a7d","instrumentation.name":"io.opentelemetry.javaagent.spring-webmvc","thread.name":"http-nio-8080-exec-1","thread.id":209}},{"id":"e14f22f12bee5a7d","trace.id":"fa6d11526ed1f9df15ef94a19381515d","timestamp":1608076314591,"attributes":{"duration.ms":915.922595,"net.peer.port":51077,"http.flavor":"HTTP/1.1","http.url":"http://localhost:8080/","instrumentation.name":"io.opentelemetry.javaagent.servlet","thread.name":"http-nio-8080-exec-1","net.peer.ip":"0:0:0:0:0:0:0:1","http.client_ip":"0:0:0:0:0:0:0:1","http.status_code":200,"instrumentation.version":"newrelic-opentelemetry-javaagent-0.12.0-SNAPSHOT-otel-0.12.1","span.kind":"SERVER","http.user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36","name":"/","http.method":"GET","thread.id":209}}]}]
[opentelemetry.auto.trace 2020-12-15 15:51:55:793 -0800] [Thread-8] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API: code: 202, body: {"requestId":"0e5e4015-0001-b000-0000-017668d14c67"}
[opentelemetry.auto.trace 2020-12-15 15:51:55:793 -0800] [Thread-8] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry batch sent
```

<img width="1250" alt="Screen Shot 2020-12-15 at 3 54 55 PM" src="https://user-images.githubusercontent.com/3496648/102287075-820d9980-3eee-11eb-8eed-3d798a92734f.png">
